### PR TITLE
feat: Add functionality for sending messages to `RemoteMC-Core` (#1)

### DIFF
--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -31,6 +31,6 @@ remotemc_mcdr:
     sending_message: 'Sending message... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
     core_url: 'RemoteMC-Core URL: {0}'
     core_connection_error: 'Message send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {0}'
-    response_received: 'Response received. Status: {0}, Message: {1}'
+    sucessful_execution_response_received: 'Message sent successfully. Status: {0}, Message: {1}'
     unsucessful_execution_response_received: 'An error occurred when trying to send the message. Status: {0}, Message: {1}'
     received_message_from_self: 'Received message sent from this server, ignore it.'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -12,6 +12,9 @@ remotemc_mcdr:
   message: Message
   broadcast: Broadcast
 
+  command_permission_level: The permission level of command {0} is {1}
+  command_perm_denied: You do not have permission to use this command.
+
   status:
     server_running: 'The Server is running'
     game_version: 'Game Version: '

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -30,6 +30,7 @@ remotemc_mcdr:
     sender_id_generated: 'Sender ID generated: {0}'
     console: 'Console'
     sending_message: 'Sending message... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
+    broadcasting: 'Broadcasting... message: {0}'
     core_url: 'RemoteMC-Core URL: {0}'
     core_connection_error: '{0} send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {1}'
     sucessful_execution_response_received: '{0} sent successfully. Status: {1}, Message: {2}'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -28,3 +28,8 @@ remotemc_mcdr:
   message_and_broadcast:
     sender_id_generated: 'Sender ID generated: {0}'
     console: 'Console'
+    sending_message: 'Sending message... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
+    core_url: 'RemoteMC-Core URL: {0}'
+    core_connection_error: 'Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {0}'
+    response_received: 'Response received. Status: {0}, Message: {1}'
+    received_message_from_self: 'Received message sent from this server, ignore it.'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -9,6 +9,7 @@ remotemc_mcdr:
 
   enable_rcon: Command executed! Enable rcon to get server response.
 
+  message: Message
   broadcast: Broadcast
 
   status:
@@ -30,7 +31,7 @@ remotemc_mcdr:
     console: 'Console'
     sending_message: 'Sending message... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
     core_url: 'RemoteMC-Core URL: {0}'
-    core_connection_error: 'Message send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {0}'
-    sucessful_execution_response_received: 'Message sent successfully. Status: {0}, Message: {1}'
-    unsucessful_execution_response_received: 'An error occurred when trying to send the message. Status: {0}, Message: {1}'
+    core_connection_error: '{0} send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {1}'
+    sucessful_execution_response_received: '{0} sent successfully. Status: {1}, Message: {2}'
+    unsucessful_execution_response_received: 'An error occurred when trying to send the {0}. Status: {1}, Message: {2}'
     received_message_from_self: 'Received message sent from this server, ignore it.'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -32,4 +32,5 @@ remotemc_mcdr:
     core_url: 'RemoteMC-Core URL: {0}'
     core_connection_error: 'Message send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {0}'
     response_received: 'Response received. Status: {0}, Message: {1}'
+    unsucessful_execution_response_received: 'An error occurred when trying to send the message. Status: {0}, Message: {1}'
     received_message_from_self: 'Received message sent from this server, ignore it.'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -24,3 +24,6 @@ remotemc_mcdr:
       line3: '§7!!remotemc §rShow this help message'
       line4: '§7!!msg §3<Message> §rSend message to all Minecraft servers and chat groups'
       line5: '§7!!broadcast §3<Message> §rBroadcast to all Minecraft servers and chat groups'
+
+  message_and_broadcast:
+    console: 'Console'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -26,4 +26,5 @@ remotemc_mcdr:
       line5: '§7!!broadcast §3<Message> §rBroadcast to all Minecraft servers and chat groups'
 
   message_and_broadcast:
+    sender_id_generated: 'Sender ID generated: {0}'
     console: 'Console'

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -30,6 +30,6 @@ remotemc_mcdr:
     console: 'Console'
     sending_message: 'Sending message... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
     core_url: 'RemoteMC-Core URL: {0}'
-    core_connection_error: 'Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {0}'
+    core_connection_error: 'Message send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {0}'
     response_received: 'Response received. Status: {0}, Message: {1}'
     received_message_from_self: 'Received message sent from this server, ignore it.'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -24,3 +24,6 @@ remotemc_mcdr:
       line3: '§7!!remotemc §r显示此帮助信息'
       line4: '§7!!msg §3<Message> §r向所有 Minecraft 服务器和聊天群发送消息'
       line5: '§7!!broadcast §3<Message> §r向所有 Minecraft 服务器和聊天群广播'
+
+  message_and_broadcast:
+    console: '控制台'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -26,4 +26,5 @@ remotemc_mcdr:
       line5: '§7!!broadcast §3<Message> §r向所有 Minecraft 服务器和聊天群广播'
 
   message_and_broadcast:
+    sender_id_generated: 'Sender ID 已生成：{0}'
     console: '控制台'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -31,6 +31,6 @@ remotemc_mcdr:
     sending_message: '正在发送消息... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
     core_url: 'RemoteMC-Core URL：{0}'
     core_connection_error: '消息发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{0}'
-    response_received: '响应已接收。状态：{0}，消息：{1}'
+    sucessful_execution_response_received: '消息已经成功发送。状态：{0}，消息：{1}'
     unsucessful_execution_response_received: '消息发送时遇到错误。状态：{0}，消息：{1}'
     received_message_from_self: '接收到来自本服务器的消息，忽略。'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -12,6 +12,9 @@ remotemc_mcdr:
   message: 消息
   broadcast: 广播
 
+  command_permission_level: 命令 {0} 的权限等级为 {1}
+  command_perm_denied: 你没有权限使用该命令。
+
   status:
     server_running: 服务器运行中
     game_version: 游戏版本：

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -32,4 +32,5 @@ remotemc_mcdr:
     core_url: 'RemoteMC-Core URL：{0}'
     core_connection_error: '消息发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{0}'
     response_received: '响应已接收。状态：{0}，消息：{1}'
+    unsucessful_execution_response_received: '消息发送时遇到错误。状态：{0}，消息：{1}'
     received_message_from_self: '接收到来自本服务器的消息，忽略。'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -28,3 +28,8 @@ remotemc_mcdr:
   message_and_broadcast:
     sender_id_generated: 'Sender ID 已生成：{0}'
     console: '控制台'
+    sending_message: '正在发送消息... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
+    core_url: 'RemoteMC-Core URL：{0}'
+    core_connection_error: '无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{0}'
+    response_received: '响应已接收。状态：{0}，消息：{1}'
+    received_message_from_self: '接收到来自本服务器的消息，忽略。'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -8,7 +8,8 @@ remotemc_mcdr:
   starting_flask: §9正在于 {0}:{1} 启动 Flask 服务端...
   
   enable_rcon: 命令已执行！启用 rcon 以获取服务器执行信息
-  
+
+  message: 消息
   broadcast: 广播
 
   status:
@@ -30,7 +31,7 @@ remotemc_mcdr:
     console: '控制台'
     sending_message: '正在发送消息... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
     core_url: 'RemoteMC-Core URL：{0}'
-    core_connection_error: '消息发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{0}'
-    sucessful_execution_response_received: '消息已经成功发送。状态：{0}，消息：{1}'
-    unsucessful_execution_response_received: '消息发送时遇到错误。状态：{0}，消息：{1}'
+    core_connection_error: '{0}发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{1}'
+    sucessful_execution_response_received: '{0}已经成功发送。状态：{1}，消息：{2}'
+    unsucessful_execution_response_received: '{0}发送时遇到错误。状态：{1}，消息：{2}'
     received_message_from_self: '接收到来自本服务器的消息，忽略。'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -30,6 +30,7 @@ remotemc_mcdr:
     sender_id_generated: 'Sender ID 已生成：{0}'
     console: '控制台'
     sending_message: '正在发送消息... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
+    broadcasting: '正在广播... message: {0}'
     core_url: 'RemoteMC-Core URL：{0}'
     core_connection_error: '{0}发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{1}'
     sucessful_execution_response_received: '{0}已经成功发送。状态：{1}，消息：{2}'

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -30,6 +30,6 @@ remotemc_mcdr:
     console: '控制台'
     sending_message: '正在发送消息... sender_id: {0}, source: {1}, sender: {2}, message: {3}'
     core_url: 'RemoteMC-Core URL：{0}'
-    core_connection_error: '无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{0}'
+    core_connection_error: '消息发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{0}'
     response_received: '响应已接收。状态：{0}，消息：{1}'
     received_message_from_self: '接收到来自本服务器的消息，忽略。'

--- a/src/remotemc_mcdr/__init__.py
+++ b/src/remotemc_mcdr/__init__.py
@@ -13,16 +13,21 @@ server: PluginServerInterface = None
 
 
 def register_commands(server: PluginServerInterface):
+    def get_literal_node(literal):
+        lvl = config.permission.get(literal, 0)
+        server.logger.info(i18n('command_permission_level', literal, lvl))
+        return Literal(f'!!{literal}').requires(lambda src: src.has_permission(lvl),
+                                         lambda: i18n('command_perm_denied'))
     server.register_command(
-        Literal(CONTROL_COMMAND_PREFIX).runs(show_help)
+        get_literal_node(CONTROL_COMMAND_PREFIX).runs(show_help)
     )
     server.register_command(
-        Literal(MESSAGE_COMMAND_PREFIX).then(
+        get_literal_node(MESSAGE_COMMAND_PREFIX).then(
             GreedyText('message').runs(send_message)
         )
     )
     server.register_command(
-        Literal(BROADCAST_COMMAND_PREFIX).then(
+        get_literal_node(BROADCAST_COMMAND_PREFIX).then(
             GreedyText('message').runs(broadcast)
         )
     )

--- a/src/remotemc_mcdr/__init__.py
+++ b/src/remotemc_mcdr/__init__.py
@@ -1,6 +1,7 @@
 from remotemc_mcdr.flask import *
 from remotemc_mcdr.commands.help_command import *
 from remotemc_mcdr.commands.msg_command import *
+from remotemc_mcdr.commands.broadcast_command import *
 from remotemc_mcdr.constants import *
 from remotemc_mcdr.util.i18n_util import *
 from remotemc_mcdr.util.config_util import *
@@ -18,6 +19,11 @@ def register_commands(server: PluginServerInterface):
     server.register_command(
         Literal(MESSAGE_COMMAND_PREFIX).then(
             GreedyText('message').runs(send_message)
+        )
+    )
+    serve.register_command(
+        Literal(BROADCAST_COMMAND_PREFIX).then(
+            GreedyText('message').runs(broadcast)
         )
     )
 

--- a/src/remotemc_mcdr/__init__.py
+++ b/src/remotemc_mcdr/__init__.py
@@ -1,9 +1,11 @@
 from remotemc_mcdr.flask import *
 from remotemc_mcdr.commands.help_command import *
+from remotemc_mcdr.commands.msg_command import *
 from remotemc_mcdr.constants import *
 from remotemc_mcdr.util.i18n_util import *
 from remotemc_mcdr.util.config_util import *
 from remotemc_mcdr.util.version_util import *
+from remotemc_mcdr.util.sender_id_util import generate_sender_id
 
 config: Configure
 server: PluginServerInterface = None
@@ -12,6 +14,11 @@ server: PluginServerInterface = None
 def register_commands(server: PluginServerInterface):
     server.register_command(
         Literal(CONTROL_COMMAND_PREFIX).runs(show_help)
+    )
+    server.register_command(
+        Literal(MESSAGE_COMMAND_PREFIX).then(
+            GreedyText('message').runs(send_message)
+        )
     )
 
 

--- a/src/remotemc_mcdr/__init__.py
+++ b/src/remotemc_mcdr/__init__.py
@@ -36,6 +36,7 @@ def on_load(plugin_server_interface: PluginServerInterface, prev):
     elif "rc" in stage:
         server.logger.info(i18n('logger.warning.release_candidate'))
     server.logger.info("==========================================================")
+    server.logger.info(i18n('message_and_broadcast.sender_id_generated', generate_sender_id()))
 
 
 def on_server_startup(plugin_server_interface: PluginServerInterface):

--- a/src/remotemc_mcdr/__init__.py
+++ b/src/remotemc_mcdr/__init__.py
@@ -21,7 +21,7 @@ def register_commands(server: PluginServerInterface):
             GreedyText('message').runs(send_message)
         )
     )
-    serve.register_command(
+    server.register_command(
         Literal(BROADCAST_COMMAND_PREFIX).then(
             GreedyText('message').runs(broadcast)
         )

--- a/src/remotemc_mcdr/commands/broadcast_command.py
+++ b/src/remotemc_mcdr/commands/broadcast_command.py
@@ -1,0 +1,47 @@
+import requests.exceptions
+
+from remotemc_mcdr.util.config_util import *
+from remotemc_mcdr.util.i18n_util import *
+
+server: PluginServerInterface = ServerInterface.get_instance().as_plugin_server_interface()
+config: Configure = load_config(server)
+
+
+def broadcast(source: CommandSource, context: dict):
+    message = context['message']
+
+    server.logger.info(i18n('message_and_broadcast.broadcasting', message))
+
+    remotemc_core_url = config.remotemc_core['host'] + ":" + config.remotemc_core['port']
+    if config.remotemc_core['ssl'] == "true":
+        remotemc_core_url = "https://" + remotemc_core_url
+    else:
+        remotemc_core_url = "http://" + remotemc_core_url
+    remotemc_core_url += "/broadcast"
+
+    server.logger.info(i18n('message_and_broadcast.core_url', remotemc_core_url))
+
+    try:
+        remotemc_core_response = requests.post(remotemc_core_url, json={
+            "authKey": config.remotemc['auth_key'],
+            "message": message
+        })
+    except requests.exceptions.ConnectionError as error:
+        server.logger.error(i18n('message_and_broadcast.core_connection_error', error))
+        server.say(i18n('message_and_broadcast.core_connection_error', error))
+        return
+
+    if remotemc_core_response.status_code == 200:
+        server.logger.info(i18n('message_and_broadcast.sucessful_execution_response_received',
+                                i18n('broadcast'),
+                                remotemc_core_response.status_code,
+                                remotemc_core_response.text))
+    else:
+        server.logger.warning(i18n('unsucessful_execution_response_received',
+                                   i18n('broadcast'),
+                                   remotemc_core_response.status_code,
+                                   remotemc_core_response.text))
+        server.say(i18n('unsucessful_execution_response_received',
+                        i18n('broadcast'),
+                        remotemc_core_response.status_code,
+                        remotemc_core_response.text))

--- a/src/remotemc_mcdr/commands/help_command.py
+++ b/src/remotemc_mcdr/commands/help_command.py
@@ -1,5 +1,3 @@
-import re
-
 from remotemc_mcdr.util.i18n_util import *
 from remotemc_mcdr.util.version_util import *
 

--- a/src/remotemc_mcdr/commands/msg_command.py
+++ b/src/remotemc_mcdr/commands/msg_command.py
@@ -1,0 +1,43 @@
+import requests.exceptions
+
+from remotemc_mcdr.util.config_util import *
+from remotemc_mcdr.util.i18n_util import *
+from remotemc_mcdr.util.sender_id_util import get_sender_id
+
+server: PluginServerInterface = ServerInterface.get_instance().as_plugin_server_interface()
+config: Configure = load_config(server)
+
+
+def send_message(source: CommandSource, context: dict):
+    sender_id = get_sender_id()
+    sender = source.player if source.is_player else i18n('message_and_broadcast.console')
+    source = config.server_name
+    message = context['message']
+
+    server.logger.info(i18n('message_and_broadcast.sending_message',
+                            sender_id, source, sender, message))
+
+    remotemc_core_url = config.remotemc_core['host'] + ":" + config.remotemc_core['port']
+    if config.remotemc_core['ssl'] == "true":
+        remotemc_core_url = "https://" + remotemc_core_url
+    else:
+        remotemc_core_url = "http://" + remotemc_core_url
+    remotemc_core_url += "/send_message"
+
+    server.logger.info(i18n('message_and_broadcast.core_url', remotemc_core_url))
+
+    try:
+        remotemc_core_response = requests.post(remotemc_core_url, json={
+            "authKey": config.remotemc['auth_key'],
+            "senderID": sender_id,
+            "source": source,
+            "sender": sender,
+            "message": message
+        })
+    except requests.exceptions.ConnectionError as error:
+        server.logger.error(i18n('message_and_broadcast.core_connection_error', error))
+        return
+
+    server.logger.info(i18n('message_and_broadcast.response_received',
+                            remotemc_core_response.status_code,
+                            remotemc_core_response.text))

--- a/src/remotemc_mcdr/commands/msg_command.py
+++ b/src/remotemc_mcdr/commands/msg_command.py
@@ -39,10 +39,14 @@ def send_message(source: CommandSource, context: dict):
         server.say(i18n('message_and_broadcast.core_connection_error', error))
         return
 
-    server.logger.info(i18n('message_and_broadcast.response_received',
-                            remotemc_core_response.status_code,
-                            remotemc_core_response.text))
-
-    if remotemc_core_response.status_code != 200:
-        server.logger.info(i18n('message_and_broadcast.message_sent'))
-        server.say(i18n('message_and_broadcast.message_sent'))
+    if remotemc_core_response.status_code == 200:
+        server.logger.info(i18n('message_and_broadcast.sucessful_execution_response_received',
+                                remotemc_core_response.status_code,
+                                remotemc_core_response.text))
+    else:
+        server.logger.warning(i18n('unsucessful_execution_response_received',
+                                   remotemc_core_response.status_code,
+                                   remotemc_core_response.text))
+        server.say(i18n('unsucessful_execution_response_received',
+                        remotemc_core_response.status_code,
+                        remotemc_core_response.text))

--- a/src/remotemc_mcdr/commands/msg_command.py
+++ b/src/remotemc_mcdr/commands/msg_command.py
@@ -36,8 +36,13 @@ def send_message(source: CommandSource, context: dict):
         })
     except requests.exceptions.ConnectionError as error:
         server.logger.error(i18n('message_and_broadcast.core_connection_error', error))
+        server.say(i18n('message_and_broadcast.core_connection_error', error))
         return
 
     server.logger.info(i18n('message_and_broadcast.response_received',
                             remotemc_core_response.status_code,
                             remotemc_core_response.text))
+
+    if remotemc_core_response.status_code != 200:
+        server.logger.info(i18n('message_and_broadcast.message_sent'))
+        server.say(i18n('message_and_broadcast.message_sent'))

--- a/src/remotemc_mcdr/commands/msg_command.py
+++ b/src/remotemc_mcdr/commands/msg_command.py
@@ -41,12 +41,15 @@ def send_message(source: CommandSource, context: dict):
 
     if remotemc_core_response.status_code == 200:
         server.logger.info(i18n('message_and_broadcast.sucessful_execution_response_received',
+                                i18n('message'),
                                 remotemc_core_response.status_code,
                                 remotemc_core_response.text))
     else:
         server.logger.warning(i18n('unsucessful_execution_response_received',
+                                   i18n('message'),
                                    remotemc_core_response.status_code,
                                    remotemc_core_response.text))
         server.say(i18n('unsucessful_execution_response_received',
+                        i18n('message'),
                         remotemc_core_response.status_code,
                         remotemc_core_response.text))

--- a/src/remotemc_mcdr/constants.py
+++ b/src/remotemc_mcdr/constants.py
@@ -2,6 +2,6 @@ from mcdreforged.api.all import PluginServerInterface, ServerInterface
 
 server: PluginServerInterface = ServerInterface.get_instance().as_plugin_server_interface()
 
-CONTROL_COMMAND_PREFIX = "!!remotemc"
-MESSAGE_COMMAND_PREFIX = "!!msg"
-BROADCAST_COMMAND_PREFIX = "!!broadcast"
+CONTROL_COMMAND_PREFIX = "remotemc"
+MESSAGE_COMMAND_PREFIX = "msg"
+BROADCAST_COMMAND_PREFIX = "broadcast"

--- a/src/remotemc_mcdr/default_config.py
+++ b/src/remotemc_mcdr/default_config.py
@@ -15,6 +15,8 @@ class Configure(Serializable):
     remotemc: Dict[str, str] = {
         "auth_key": "you_should_change_this",
     }
+
+    server_name: str = "RemoteMC-MCDR Default Server Name"
     
     minecraft_server: Dict[str, str] = {
         "host": "127.0.0.1",

--- a/src/remotemc_mcdr/default_config.py
+++ b/src/remotemc_mcdr/default_config.py
@@ -34,4 +34,9 @@ class Configure(Serializable):
     }
 
     server_name: str = "RemoteMC-MCDR Default Server Name"
+
+    permission: Dict[str, int] = {
+        'msg': 0,
+        'broadcast': 3
+    }
     

--- a/src/remotemc_mcdr/default_config.py
+++ b/src/remotemc_mcdr/default_config.py
@@ -16,7 +16,11 @@ class Configure(Serializable):
         "auth_key": "you_should_change_this",
     }
 
-    server_name: str = "RemoteMC-MCDR Default Server Name"
+    remotemc_core: Dict[str, str] = {
+        'host': "127.0.0.1",
+        'port': "65360",
+        'ssl': "false",
+    }
     
     minecraft_server: Dict[str, str] = {
         "host": "127.0.0.1",
@@ -28,10 +32,6 @@ class Configure(Serializable):
         'host': "127.0.0.1",
         'port': "65362",
     }
-    
-    remotemc_core: Dict[str, str] = {
-        'host': "127.0.0.1",
-        'port': "65360",
-        'ssl': "false",
-    }
+
+    server_name: str = "RemoteMC-MCDR Default Server Name"
     

--- a/src/remotemc_mcdr/flask.py
+++ b/src/remotemc_mcdr/flask.py
@@ -4,6 +4,7 @@ from mcstatus import JavaServer
 
 from remotemc_mcdr.util.html_response_util import *
 from remotemc_mcdr.util.config_util import *
+from remotemc_mcdr.util.sender_id_util import is_the_same_sender_id
 
 server: PluginServerInterface = ServerInterface.get_instance().as_plugin_server_interface()
 
@@ -76,6 +77,11 @@ def say():
 
     if not auth_key == content['auth_key']:
         return get_401_response()
+
+    sender_id = content['sender_id']
+
+    if is_the_same_sender_id(sender_id):
+        return get_200_response()
 
     source = content['source']
     sender = content['sender']

--- a/src/remotemc_mcdr/flask.py
+++ b/src/remotemc_mcdr/flask.py
@@ -81,6 +81,7 @@ def say():
     sender_id = content['sender_id']
 
     if is_the_same_sender_id(sender_id):
+        server.logger.info(i18n('message_and_broadcast.received_message_from_self'))
         return get_200_response()
 
     source = content['source']

--- a/src/remotemc_mcdr/util/sender_id_util.py
+++ b/src/remotemc_mcdr/util/sender_id_util.py
@@ -11,3 +11,7 @@ def generate_sender_id():
 
 def get_sender_id():
     return sender_id
+
+
+def is_the_same_sender_id(received_sender_id: str):
+    return received_sender_id == sender_id

--- a/src/remotemc_mcdr/util/sender_id_util.py
+++ b/src/remotemc_mcdr/util/sender_id_util.py
@@ -1,0 +1,13 @@
+import uuid
+
+sender_id: str
+
+
+def generate_sender_id():
+    global sender_id
+    sender_id = uuid.uuid4().hex.upper()
+    return sender_id
+
+
+def get_sender_id():
+    return sender_id


### PR DESCRIPTION
Add two commands:

- `!!msg`: Send the message to `RemoteMC-Core` and let the message be forwarded to other clients.
- `!!broadcast`: Send the broadcast to `RemoteMC-Core` and let the message broadcast to other clients.


resolves: #1 