### PR TITLE
refactor: Implementation of new response handler for Universal Chat and Broadcast APIs (#10)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -2,9 +2,11 @@ name: Build dev version artifacts
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - "**"
   pull_request:
-    branches: [ main ]
+    branches:
+      - "**"
 
 jobs:
   build:

--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -75,6 +75,7 @@ remotemc_mcdr:
     broadcasting: "Broadcasting... message: {0}"
     core_url: "RemoteMC-Core URL: {0}"
     core_connection_error: "{0} send unsuccessfully! Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? ConnectionError: {1}"
+    core_response_list: "Response List received from RemoteMC-Core:\n{0}"
     sucessful_execution_response_received: "{0} sent successfully. Status: {1}, Message: {2}"
     unsucessful_execution_response_received: "An error occurred when trying to send the {0}. Status: {1}, Message: {2}"
     received_message_from_self: "Received message sent from this server, ignore it."

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -74,6 +74,7 @@ remotemc_mcdr:
     broadcasting: "正在广播... message: {0}"
     core_url: "RemoteMC-Core URL：{0}"
     core_connection_error: "{0}发送失败！无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？连接错误：{1}"
+    core_response_list: "从 RemoteMC-Core 接收到的响应列表：\n{0}"
     sucessful_execution_response_received: "{0}已经成功发送。状态：{1}，消息：{2}"
     unsucessful_execution_response_received: "{0}发送时遇到错误。状态：{1}，消息：{2}"
     received_message_from_self: "接收到来自本服务器的消息，忽略。"

--- a/src/remotemc_mcdr/commands/broadcast_command.py
+++ b/src/remotemc_mcdr/commands/broadcast_command.py
@@ -31,17 +31,17 @@ def broadcast(source: CommandSource, context: dict):
         server.say(i18n("message_and_broadcast.core_connection_error", error))
         return
 
-    if remotemc_core_response.status_code == 200:
-        server.logger.info(i18n("message_and_broadcast.sucessful_execution_response_received",
-                                i18n("broadcast"),
-                                remotemc_core_response.status_code,
-                                remotemc_core_response.text))
-    else:
-        server.logger.warning(i18n("unsucessful_execution_response_received",
-                                   i18n("broadcast"),
-                                   remotemc_core_response.status_code,
-                                   remotemc_core_response.text))
-        server.say(i18n("unsucessful_execution_response_received",
-                        i18n("broadcast"),
-                        remotemc_core_response.status_code,
-                        remotemc_core_response.text))
+    remotemc_core_response_list = remotemc_core_response.json()["responseList"]
+    server.logger.info(i18n("message_and_broadcast.core_response_list", remotemc_core_response_list))
+
+    for response in remotemc_core_response_list:
+        status_code = response["statusCode"]
+        message = response["message"]
+        if status_code == 200:
+            server.logger.info(i18n("message_and_broadcast.sucessful_execution_response_received",
+                                    i18n("broadcast"), status_code, message))
+        else:
+            server.logger.warning(i18n("message_and_broadcast.unsucessful_execution_response_received",
+                                       i18n("broadcast"), status_code, message))
+            server.say(i18n("message_and_broadcast.unsucessful_execution_response_received",
+                            i18n("broadcast"), status_code, message))

--- a/src/remotemc_mcdr/commands/msg_command.py
+++ b/src/remotemc_mcdr/commands/msg_command.py
@@ -39,17 +39,17 @@ def send_message(source: CommandSource, context: dict):
         server.say(i18n("message_and_broadcast.core_connection_error", error))
         return
 
-    if remotemc_core_response.status_code == 200:
-        server.logger.info(i18n("message_and_broadcast.sucessful_execution_response_received",
-                                i18n("message"),
-                                remotemc_core_response.status_code,
-                                remotemc_core_response.text))
-    else:
-        server.logger.warning(i18n("message_and_broadcast.unsucessful_execution_response_received",
-                                   i18n("message"),
-                                   remotemc_core_response.status_code,
-                                   remotemc_core_response.text))
-        server.say(i18n("message_and_broadcast.unsucessful_execution_response_received",
-                        i18n("message"),
-                        remotemc_core_response.status_code,
-                        remotemc_core_response.text))
+    remotemc_core_response_list = remotemc_core_response.json()["responseList"]
+    server.logger.info(i18n("message_and_broadcast.core_response_list", remotemc_core_response_list))
+
+    for response in remotemc_core_response_list:
+        status_code = response["statusCode"]
+        message = response["message"]
+        if status_code == 200:
+            server.logger.info(i18n("message_and_broadcast.sucessful_execution_response_received",
+                                    i18n("message"), status_code, message))
+        else:
+            server.logger.warning(i18n("message_and_broadcast.unsucessful_execution_response_received",
+                                       i18n("message"), status_code, message))
+            server.say(i18n("message_and_broadcast.unsucessful_execution_response_received",
+                            i18n("message"), status_code, message))


### PR DESCRIPTION
These changes are made due to the changes in the response style of Universal Chat and Broadcast APIs of Remote-MC Core since [Version 0.2.1 Beta (BD259A6)](https://github.com/iXORTech/RemoteMC-Core/releases/tag/v0.2.1-beta).

Check also commit https://github.com/iXORTech/RemoteMC-Core/commit/41ded303f4bf287a41d10c1a5da01eb7b2a9bc8a to learn more about the changes.

fix: #10