### PR TITLE
feat: Check the compatibility with RemoteMC-Core when starting

### DIFF
--- a/src/lang/en_us.yml
+++ b/src/lang/en_us.yml
@@ -4,6 +4,11 @@ remotemc_mcdr:
   json_parsing_error: "§cCustom JSON Parsing Error"
   logger.warning.experimental: "§cTHIS IS IN EXPERIMENTAL STAGE, DO NOT USE IN PRODUCTION ENVIRONMENT!"
   logger.warning.release_candidate: "§cTHIS IS A RELEASE CANDIDATE, DO NOT USE IN PRODUCTION ENVIRONMENT!"
+
+  logger.warning.core_incompatible: "§6Connected to an incompatible version of RemoteMC-Core! Please update RemoteMC-Core to the latest version."
+  logger.warning.core_unknown_error: "§cAn unknown error occurred when trying to connect to RemoteMC-Core!"
+  logger.warning.core_not_connected: "§6Cannot connect to RemoteMC-Core! Is RemoteMC-Core running? Is the address of RemoteMC-Core in config correct?"
+
   loading_flask: "§9Loading Flask framework..."
   starting_flask: "§9Starting Flask Server on {0}:{1}..."
 

--- a/src/lang/zh_cn.yml
+++ b/src/lang/zh_cn.yml
@@ -6,6 +6,10 @@ remotemc_mcdr:
   logger.warning.release_candidate: "§c该程序仍然处于发布候选阶段，请不要应用于生产环境！"
   loading_flask: "§9正在加载 Flask 框架..."
   starting_flask: "§9正在于 {0}:{1} 启动 Flask 服务端..."
+
+  logger.warning.core_incompatible: "§6已连接到不兼容的 RemoteMC-Core！请更新 RemoteMC-Core 至最新版本。"
+  logger.warning.core_unknown_error: "§c在尝试连接 RemoteMC-Core 时发生未知错误！"
+  logger.warning.core_not_connected: "§6无法连接到 RemoteMC-Core！RemoteMC-Core 是否正在运行？配置文件中的 RemoteMC-Core 地址是否正确？"
   
   enable_rcon: "命令已执行！启用 rcon 以获取服务器执行信息"
 

--- a/src/remotemc_mcdr/__init__.py
+++ b/src/remotemc_mcdr/__init__.py
@@ -74,6 +74,17 @@ def on_load(plugin_server_interface: PluginServerInterface, prev):
     server.logger.info("==========================================================")
     generate_sender_id()
 
+    remotemc_core_host = config.remotemc_core["host"]
+    remotemc_core_port = int(config.remotemc_core["port"])
+    remotemc_core_ssl = True if config.remotemc_core["ssl"].lower() == "true" else False
+    remotemc_core_check_status = remotemc_core_check(remotemc_core_host, remotemc_core_port, remotemc_core_ssl)
+    if remotemc_core_check_status == RemoteMCCoreStatus.INCOMPATIBLE:
+        server.logger.warning(i18n("logger.warning.core_incompatible"))
+    elif remotemc_core_check_status == RemoteMCCoreStatus.UNKNOWN_ERROR:
+        server.logger.error(i18n("logger.warning.core_unknown_error"))
+    elif remotemc_core_check_status == RemoteMCCoreStatus.NOT_CONNECTED:
+        server.logger.warning(i18n("logger.warning.core_not_connected"))
+
 
 def on_server_startup(plugin_server_interface: PluginServerInterface):
     load_flask()


### PR DESCRIPTION
Show a warning in the console when loading the plugin if connected to an incompatible RemoteMC-Core or cannot connect to a RemoteMC-Core server.

resolve: #16